### PR TITLE
Switch out regular forms for react-hook-form

### DIFF
--- a/src/components/boards/new-board-column.tsx
+++ b/src/components/boards/new-board-column.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styled from "styled-components";
 import { drelloColors } from "../../constants/colors";
+import { SubmitHandler, useForm } from "react-hook-form";
 
 const NewColumnContainer = styled.div`
   display: grid;
@@ -30,7 +31,11 @@ const DisplayContainer = styled(InnerContainer)`
   }
 `;
 
-const EditContainer = styled(InnerContainer)`
+const EditContainer = styled.form`
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.2rem;
   background-color: ${drelloColors.greyish()};
 `;
 
@@ -61,13 +66,17 @@ const FAIcon = styled(FontAwesomeIcon)`
   color: ${drelloColors.black(0.6)};
 `;
 
+type FormInputs = {
+  columnTitle: string;
+};
+
 export const NewBoardColumn = () => {
-  const [columnTitle, setColumnTitle] = useState("");
+  const { register, handleSubmit } = useForm<FormInputs>();
   const [inputToggle, setInputToggle] = useState(true);
 
-  const addColumn = (e: React.SyntheticEvent) => {
+  const addColumn: SubmitHandler<FormInputs> = (data) => {
     /* TODO: Implement add Column function */
-    e.preventDefault();
+    console.log(data);
     setInputToggle(true);
     console.log("Implement function to addColumn ideally with redux");
   };
@@ -79,11 +88,10 @@ export const NewBoardColumn = () => {
           <span>Add new column</span>
         </DisplayContainer>
       ) : (
-        <EditContainer onSubmit={addColumn}>
+        <EditContainer onSubmit={handleSubmit(addColumn)}>
           <ColumnInput
             placeholder="Enter title here..."
-            value={columnTitle}
-            onChange={(e) => setColumnTitle(e.target.value)}
+            {...register("columnTitle")}
           />
           <FormActions>
             <FormButton>Add Column</FormButton>

--- a/src/components/columns/new-column-card.tsx
+++ b/src/components/columns/new-column-card.tsx
@@ -2,15 +2,19 @@ import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styled from "styled-components";
 import { drelloColors } from "../../constants/colors";
-import { Card } from "../../types/inner/board.g";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { Card } from "src/types/inner/board.g";
 
-const InnerContainer = styled.div`
+const FormContainer = styled.form`
   display: grid;
   gap: 0.5rem;
   border-radius: 0.2rem;
 `;
 
-const DisplayContainer = styled(InnerContainer)`
+const DisplayContainer = styled.div`
+  display: grid;
+  gap: 0.5rem;
+  border-radius: 0.2rem;
   grid-auto-flow: column;
   align-items: center;
   justify-content: flex-start;
@@ -49,12 +53,12 @@ const FAIcon = styled(FontAwesomeIcon)`
 `;
 
 export const NewColumnCard = () => {
-  const [cardTitle, setCardTitle] = useState("");
+  const { register, handleSubmit } = useForm<Card>();
   const [inputToggle, setInputToggle] = useState(true);
 
-  const addCard = (e: React.SyntheticEvent) => {
+  const addCard: SubmitHandler<Card> = (data) => {
     /* TODO: Implement add Card function */
-    e.preventDefault();
+    console.log(data);
     setInputToggle(true);
     console.log("Implement function to addCard ideally with redux");
   };
@@ -64,16 +68,12 @@ export const NewColumnCard = () => {
       <span>Add a Card</span>
     </DisplayContainer>
   ) : (
-    <InnerContainer onSubmit={addCard}>
-      <CardInput
-        placeholder="Enter title here..."
-        value={cardTitle}
-        onChange={(e) => setCardTitle(e.target.value)}
-      />
+    <FormContainer onSubmit={handleSubmit(addCard)}>
+      <CardInput placeholder="Enter title here..." {...register("cardTitle")} />
       <FormActions>
         <FormButton>Add Card</FormButton>
         <FAIcon icon="times" onClick={() => setInputToggle(true)} />
       </FormActions>
-    </InnerContainer>
+    </FormContainer>
   );
 };

--- a/src/components/columns/new-column-card.tsx
+++ b/src/components/columns/new-column-card.tsx
@@ -52,11 +52,15 @@ const FAIcon = styled(FontAwesomeIcon)`
   color: ${drelloColors.black(0.6)};
 `;
 
+type FormInputs = {
+  cardTitle: string;
+};
+
 export const NewColumnCard = () => {
-  const { register, handleSubmit } = useForm<Card>();
+  const { register, handleSubmit } = useForm<FormInputs>();
   const [inputToggle, setInputToggle] = useState(true);
 
-  const addCard: SubmitHandler<Card> = (data) => {
+  const addCard: SubmitHandler<FormInputs> = (data) => {
     /* TODO: Implement add Card function */
     console.log(data);
     setInputToggle(true);

--- a/src/pages/boards/[id].tsx
+++ b/src/pages/boards/[id].tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 import Image from "next/image";
 import { BoardNavbar } from "../../components/boards/board-navbar";
@@ -7,7 +5,6 @@ import { BoardColumn } from "../../components/boards/board-column";
 import { drelloBoardsList } from "../../utils/mockdata/drello-boards";
 import { Column } from "../../types/inner/board.g";
 import { NewBoardColumn } from "../../components/boards/new-board-column";
-import { getBoardsThunk, selectBoards } from "src/redux/domain/board";
 import { BoardSubnav } from "src/components/boards/board-subnav";
 
 const BoardMain = styled.main`
@@ -35,24 +32,11 @@ const BoardContainer = styled.section`
 `;
 
 const Board = () => {
-  //******* Sample Code for Redux Toolkit *******//
-  // const dispatch = useDispatch();
-
-  // // This is how to get state from redux store.
-  // const boards = useSelector(selectBoards);
-  // console.log(boards);
-
-  // useEffect(() => {
-  //   // This is how to dispatch actions.
-  //   dispatch(getBoardsThunk());
-  // }, []);
-  //************************************************//
-
   return (
     <>
       <BoardImage
-        src={drelloBoardsList[2].image?.src || "/images/template-1.JPG"}
-        alt={drelloBoardsList[2].image?.alt}
+        src={drelloBoardsList[2].boardImage?.src || "/images/template-1.JPG"}
+        alt={drelloBoardsList[2].boardImage?.alt}
         layout="fill"
         objectFit="cover"
         objectPosition="center"

--- a/src/types/inner/board.g.ts
+++ b/src/types/inner/board.g.ts
@@ -17,7 +17,7 @@ export interface Column {
   cards?: Card[];
 }
 
-export interface Image {
+export interface BoardImage {
   src: string;
   alt: string;
 }
@@ -26,7 +26,7 @@ export interface Board {
   id: number;
   title: string;
   focus?: boolean;
-  image?: Image;
+  boardImage?: BoardImage;
   workspace?: Workspace;
   stats?: Stats[];
   columns?: Column[];

--- a/src/utils/mockdata/drello-boards.ts
+++ b/src/utils/mockdata/drello-boards.ts
@@ -53,7 +53,7 @@ export const drelloBoardsList = [
       type: "Engineering - IT",
       description: "",
     },
-    image: {
+    boardImage: {
       src: "/images/template-1.JPG",
       alt: "Drello board image",
     },


### PR DESCRIPTION
Used react-hook-form for the forms inside the board page, including, the "new-board-column" and "new-column-card" components