### PR TITLE
Enable to drag and drop to cards without connecting APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/node": "^16.4.2",
     "@types/react": "^17.0.15",
+    "@types/react-beautiful-dnd": "^13.1.2",
     "@types/react-redux": "^7.1.19",
     "@types/styled-components": "^5.1.12",
     "axios": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "firebase": "^9.1.3",
     "next": "11.0.1",
     "react": "17.0.2",
+    "react-beautiful-dnd": "^13.1.0",
     "react-dom": "17.0.2",
     "styled-components": "^5.3.0"
   },

--- a/src/features/auth/auth.slice.ts
+++ b/src/features/auth/auth.slice.ts
@@ -83,8 +83,10 @@ export const slice = createSlice({
   },
 });
 
+// Selectors
 export const selectIdToken = () => (state: RootState) =>
   state.authState.idToken;
 
+// Reducer & Actions
 export const { resetAuth } = slice.actions;
 export const authReducer = slice.reducer;

--- a/src/features/board/board.api.ts
+++ b/src/features/board/board.api.ts
@@ -11,6 +11,7 @@ export interface Column {
   id: number;
   title: string;
   boardId: number;
+  headCardId?: number;
 }
 export interface Card {
   id: number;

--- a/src/features/board/board.api.ts
+++ b/src/features/board/board.api.ts
@@ -4,7 +4,7 @@ import { path } from "src/utils/url/drello-api";
 export interface Board {
   id: number;
   title: string;
-  columns: Column[];
+  columns?: Column[];
   cards?: Card[];
 }
 export interface Column {

--- a/src/features/board/board.api.ts
+++ b/src/features/board/board.api.ts
@@ -9,7 +9,8 @@ export interface Board {
 }
 export interface Column {
   id: number;
-  title?: string;
+  title: string;
+  boardId: number;
 }
 export interface Card {
   id: number;

--- a/src/features/board/board.api.ts
+++ b/src/features/board/board.api.ts
@@ -16,6 +16,7 @@ export interface Card {
   id: number;
   title: string;
   columnId: number;
+  nextCardId: number;
 }
 
 export const getBoard = ({

--- a/src/features/board/board.slice.ts
+++ b/src/features/board/board.slice.ts
@@ -46,7 +46,9 @@ export const slice = createSlice({
   },
 });
 
+// Selectors
 export const selectBoardById = (boardId: number) => (state: RootState) =>
   state.boardState.boards.find((board) => board.id === boardId);
 
+// Reducer & Actions
 export const boardReducer = slice.reducer;

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -16,12 +16,14 @@ const Container = styled.section`
 `;
 
 export const Board = () => {
+  const onDragEnd = () => {};
+
   return (
-    <>
+    <DragDropContext onDragEnd={onDragEnd}>
       <Container>
         <ColumnList />
         <NewColumn />
       </Container>
-    </>
+    </DragDropContext>
   );
 };

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -2,8 +2,8 @@ import styled from "styled-components";
 import { NewColumn } from "src/features/column/new-column";
 import { ColumnList } from "src/features/column/column-list";
 import { DragDropContext, DropResult } from "react-beautiful-dnd";
-import { useDispatch, useSelector } from "react-redux";
-import { reorderCards, selectCards } from "src/features/card/card.slice";
+import { useDispatch } from "react-redux";
+import { moveCards } from "src/features/card/card.slice";
 
 const Container = styled.section`
   display: grid;
@@ -23,19 +23,20 @@ interface BoardProps {
 
 export const Board = ({ boardId }: BoardProps) => {
   const dispatch = useDispatch();
-  const cards = useSelector(selectCards());
 
-  const onDragEnd = (result: DropResult) => {
-    if (!result.destination) {
+  const onDragEnd = ({ source, destination, draggableId }: DropResult) => {
+    if (!destination) {
       // dropped outside the list
       return;
     }
 
     dispatch(
-      reorderCards({
-        cards: cards,
-        startIndex: result.source.index,
-        endIndex: result.destination.index,
+      moveCards({
+        targetCardId: parseInt(draggableId),
+        startIndex: source.index,
+        endIndex: destination.index,
+        startColumnId: parseInt(source.droppableId),
+        endColumnId: parseInt(destination.droppableId),
       })
     );
   };

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -26,17 +26,27 @@ export const Board = ({ boardId }: BoardProps) => {
 
   const onDragEnd = ({ source, destination, draggableId }: DropResult) => {
     if (!destination) {
-      // dropped outside the list
+      // Dropped outside the list
+      return;
+    }
+
+    const startIndex = source.index;
+    const endIndex = destination.index;
+    const startColumnId = parseInt(source.droppableId);
+    const endColumnId = parseInt(destination.droppableId);
+
+    if (startIndex === endIndex && startColumnId === endColumnId) {
+      // Dropped at the original position (= No change)
       return;
     }
 
     dispatch(
       moveCards({
         targetCardId: parseInt(draggableId),
-        startIndex: source.index,
-        endIndex: destination.index,
-        startColumnId: parseInt(source.droppableId),
-        endColumnId: parseInt(destination.droppableId),
+        startIndex,
+        endIndex,
+        startColumnId,
+        endColumnId,
       })
     );
   };

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+import { NewColumn } from "src/features/column/new-column";
+import { ColumnList } from "src/features/column/column-list";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+
+const Container = styled.section`
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  gap: 1rem;
+  padding: 1em;
+  justify-content: start;
+  justify-items: start;
+  align-items: flex-start;
+  overflow-x: auto;
+`;
+
+export const Board = () => {
+  return (
+    <>
+      <Container>
+        <ColumnList />
+        <NewColumn />
+      </Container>
+    </>
+  );
+};

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -1,12 +1,7 @@
 import styled from "styled-components";
 import { NewColumn } from "src/features/column/new-column";
 import { ColumnList } from "src/features/column/column-list";
-import {
-  DragDropContext,
-  DropResult,
-  Droppable,
-  Draggable,
-} from "react-beautiful-dnd";
+import { DragDropContext, DropResult } from "react-beautiful-dnd";
 import { useDispatch, useSelector } from "react-redux";
 import { reorderCards, selectCards } from "src/features/card/card.slice";
 

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -1,7 +1,14 @@
 import styled from "styled-components";
 import { NewColumn } from "src/features/column/new-column";
 import { ColumnList } from "src/features/column/column-list";
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import {
+  DragDropContext,
+  DropResult,
+  Droppable,
+  Draggable,
+} from "react-beautiful-dnd";
+import { useDispatch, useSelector } from "react-redux";
+import { reorderCards, selectCards } from "src/features/card/card.slice";
 
 const Container = styled.section`
   display: grid;
@@ -16,7 +23,23 @@ const Container = styled.section`
 `;
 
 export const Board = () => {
-  const onDragEnd = () => {};
+  const dispatch = useDispatch();
+  const cards = useSelector(selectCards());
+
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) {
+      // dropped outside the list
+      return;
+    }
+
+    dispatch(
+      reorderCards({
+        cards: cards,
+        startIndex: result.source.index,
+        endIndex: result.destination.index,
+      })
+    );
+  };
 
   return (
     <DragDropContext onDragEnd={onDragEnd}>

--- a/src/features/board/board.tsx
+++ b/src/features/board/board.tsx
@@ -17,7 +17,11 @@ const Container = styled.section`
   overflow-x: auto;
 `;
 
-export const Board = () => {
+interface BoardProps {
+  boardId: number;
+}
+
+export const Board = ({ boardId }: BoardProps) => {
   const dispatch = useDispatch();
   const cards = useSelector(selectCards());
 
@@ -39,7 +43,7 @@ export const Board = () => {
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <Container>
-        <ColumnList />
+        <ColumnList boardId={boardId} />
         <NewColumn />
       </Container>
     </DragDropContext>

--- a/src/features/card/card-list.tsx
+++ b/src/features/card/card-list.tsx
@@ -1,22 +1,19 @@
 import { useSelector } from "react-redux";
 import { Card } from "src/features/card/card";
-import { selectCards } from "src/features/card/card.slice";
+import { selectCardsByColumnId } from "src/features/card/card.slice";
 
 interface CardListProps {
   columnId: number;
 }
 
 export const CardList = ({ columnId }: CardListProps) => {
-  const cards = useSelector(selectCards());
+  const cards = useSelector(selectCardsByColumnId(columnId));
 
   return (
     <>
-      {cards?.map(
-        (card, index) =>
-          columnId === card.columnId && (
-            <Card key={card.id} card={card} index={index} />
-          )
-      )}
+      {cards?.map((card, index) => (
+        <Card key={card.id} card={card} index={index} />
+      ))}
     </>
   );
 };

--- a/src/features/card/card-list.tsx
+++ b/src/features/card/card-list.tsx
@@ -8,12 +8,13 @@ interface CardListProps {
 
 export const CardList = ({ columnId }: CardListProps) => {
   const cards = useSelector(selectCards());
+
   return (
     <>
       {cards?.map(
-        (card) =>
+        (card, index) =>
           columnId === card.columnId && (
-            <Card key={card.id} title={card.title} />
+            <Card key={card.id} card={card} index={index} />
           )
       )}
     </>

--- a/src/features/card/card-list.tsx
+++ b/src/features/card/card-list.tsx
@@ -7,7 +7,7 @@ interface CardListProps {
 }
 
 export const CardList = ({ columnId }: CardListProps) => {
-  const cards = useSelector(selectCards);
+  const cards = useSelector(selectCards());
   return (
     <>
       {cards?.map(

--- a/src/features/card/card.g.ts
+++ b/src/features/card/card.g.ts
@@ -2,4 +2,5 @@ export interface Card {
   id: number;
   title: string;
   columnId: number;
+  nextCardId: number;
 }

--- a/src/features/card/card.g.ts
+++ b/src/features/card/card.g.ts
@@ -2,5 +2,5 @@ export interface Card {
   id: number;
   title: string;
   columnId: number;
-  nextCardId: number;
+  nextCardId: number | null;
 }

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -71,10 +71,10 @@ export const slice = createSlice({
 
         const updateLinkedListPointers = () => {
           const nextSourseCardId = targetCardList[startIndex + 1]?.id || null;
-          const prevSourseCard = targetCardList[startIndex - 1];
 
           if (startIndex > 0) {
             // There is a previous card. Need to update next ID of previous card.
+            const prevSourseCard = targetCardList[startIndex - 1];
             prevSourseCard.nextCardId = nextSourseCardId;
           } else {
             // There is no previous card. Need to update head's card ID of target column.

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -50,13 +50,11 @@ export const slice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(getBoardThunk.fulfilled, (state, action) => {
-      const data = action.payload?.data;
-      if (data) {
-        data.cards
-          ? (state.cards = data.cards.map((card) =>
-              convertCardToInnerType(card)
-            ))
-          : (state.cards = []);
+      const cards = action.payload?.data?.cards;
+      if (cards) {
+        state.cards = cards.map((card) => convertCardToInnerType(card));
+      } else {
+        state.cards = [];
       }
     });
     builder.addCase(getBoardThunk.rejected, (state, action) => {

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -5,13 +5,11 @@ import { RootState } from "src/utils/redux/root";
 import { getBoardThunk } from "src/features/board/board.slice";
 
 interface CardState {
-  cards: InnerCard[];
-  cardsByColumnId: Record<number, InnerCard[]> | null;
+  cardsByColumnId: Record<number, InnerCard[]>;
 }
 
 const initialState: CardState = {
-  cards: [],
-  cardsByColumnId: null,
+  cardsByColumnId: {},
 };
 
 const convertCardToInnerType = (ob: OuterCard): InnerCard => {
@@ -32,7 +30,7 @@ export const slice = createSlice({
         title: action.payload.title,
         columnId: action.payload.columnId,
       };
-      state.cards.push(newItem);
+      state.cardsByColumnId[action.payload.columnId].push(newItem);
     },
     moveCards: (
       state,
@@ -46,8 +44,6 @@ export const slice = createSlice({
     ) => {
       const { targetCardId, startIndex, endIndex, startColumnId, endColumnId } =
         action.payload;
-
-      if (!state.cardsByColumnId) return state;
 
       const checkCardIds = (
         manipulatedCardId: number,
@@ -88,7 +84,7 @@ export const slice = createSlice({
     builder.addCase(getBoardThunk.fulfilled, (state, action) => {
       const cards = action.payload?.data?.cards;
       if (!cards) {
-        state.cards = [];
+        state.cardsByColumnId = [];
         return state;
       }
 
@@ -112,11 +108,8 @@ export const slice = createSlice({
 });
 
 // Selectors
-export const selectCardsByColumnId =
-  (columnId: number) => (state: RootState) => {
-    if (!state.cardState.cardsByColumnId) return [];
-    return state.cardState.cardsByColumnId[columnId];
-  };
+export const selectCardsByColumnId = (columnId: number) => (state: RootState) =>
+  state.cardState.cardsByColumnId[columnId];
 
 // Reducer & Actions
 export const { addCard, moveCards } = slice.actions;

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -76,21 +76,23 @@ export const slice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(getBoardThunk.fulfilled, (state, action) => {
       const cards = action.payload?.data?.cards;
-      if (cards) {
-        const cardsByColumnId: Record<number, InnerCard[]> = {};
-        cards
-          .map((card) => convertCardToInnerType(card))
-          .forEach((card) => {
-            if (cardsByColumnId[card.columnId]) {
-              cardsByColumnId[card.columnId].push(card);
-            } else {
-              cardsByColumnId[card.columnId] = [card];
-            }
-          });
-        state.cardsByColumnId = cardsByColumnId;
-      } else {
+      if (!cards) {
         state.cards = [];
+        return state;
       }
+
+      const cardsByColumnId: Record<number, InnerCard[]> = {};
+      cards
+        .map((card) => convertCardToInnerType(card))
+        .forEach((card) => {
+          if (cardsByColumnId[card.columnId]) {
+            cardsByColumnId[card.columnId].push(card);
+          } else {
+            cardsByColumnId[card.columnId] = [card];
+          }
+        });
+
+      state.cardsByColumnId = cardsByColumnId;
     });
     builder.addCase(getBoardThunk.rejected, (state, action) => {
       console.error(action.error.message);

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -12,11 +12,12 @@ const initialState: CardState = {
   cardsByColumnId: {},
 };
 
-const convertCardToInnerType = (ob: OuterCard): InnerCard => {
+const convertCardToInnerType = (outerCard: OuterCard): InnerCard => {
   return {
-    id: ob.id,
-    title: ob.title,
-    columnId: ob.columnId,
+    id: outerCard.id,
+    title: outerCard.title,
+    columnId: outerCard.columnId,
+    nextCardId: outerCard.nextCardId,
   };
 };
 
@@ -24,11 +25,13 @@ export const slice = createSlice({
   name: "card",
   initialState,
   reducers: {
+    // [TODO] Set proper type to action
     addCard: (state, action) => {
       const newItem = {
         id: Math.floor(100000 + Math.random() * 900000),
         title: action.payload.title,
         columnId: action.payload.columnId,
+        nextCardId: action.payload.nextCardId,
       };
       state.cardsByColumnId[action.payload.columnId].push(newItem);
     },

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -35,6 +35,10 @@ export const slice = createSlice({
       };
       state.cardsByColumnId[action.payload.columnId].push(newItem);
     },
+    /**
+     * This reducer is temporary implemented.
+     * [TODO]: Use thunk later to connect to APIs
+     */
     moveCards: (
       state,
       action: PayloadAction<{
@@ -63,9 +67,23 @@ export const slice = createSlice({
         // Reorder cards in the same column.
         const targetCardList = [...state.cardsByColumnId[startColumnId]];
         const [removedCard] = targetCardList.splice(startIndex, 1);
+
+        const nextSourseCardId = targetCardList[startIndex + 1]?.id || null;
+        if (startIndex > 0) {
+          targetCardList[startIndex - 1].nextCardId = nextSourseCardId;
+        } else {
+          console.log("Should update headerCardId of column");
+          // [TODO]: Update headerCardId of column state
+        }
+
+        const nextDestCardId = targetCardList[endIndex + 1]?.id || null;
+        removedCard.nextCardId = nextDestCardId;
+
         targetCardList.splice(endIndex, 0, removedCard);
 
         checkCardIds(removedCard.id, targetCardId);
+
+        // [TODO]: Update
 
         state.cardsByColumnId[startColumnId] = targetCardList;
         return state;
@@ -75,6 +93,8 @@ export const slice = createSlice({
         const [removedCard] = sourceCardList.splice(startIndex, 1);
         const destCardList = [...state.cardsByColumnId[endColumnId]];
         destCardList.splice(endIndex, 0, removedCard);
+
+        // [TODO]: Enable to change nextCardId and headCardID then hit API to update data in database.
 
         checkCardIds(removedCard.id, targetCardId);
 

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -49,11 +49,24 @@ export const slice = createSlice({
 
       if (!state.cardsByColumnId) return state;
 
+      const checkCardIds = (
+        manipulatedCardId: number,
+        targetCardId: number
+      ) => {
+        if (manipulatedCardId !== targetCardId) {
+          // Unexpected card is chosen
+          window.alert("Failed moving the card. Please try again.");
+          return state;
+        }
+      };
+
       if (startColumnId === endColumnId) {
         // Reorder cards in the same column.
         const targetCardList = [...state.cardsByColumnId[startColumnId]];
         const [removedCard] = targetCardList.splice(startIndex, 1);
         targetCardList.splice(endIndex, 0, removedCard);
+
+        checkCardIds(removedCard.id, targetCardId);
 
         state.cardsByColumnId[startColumnId] = targetCardList;
         return state;
@@ -64,11 +77,7 @@ export const slice = createSlice({
         const destCardList = [...state.cardsByColumnId[endColumnId]];
         destCardList.splice(endIndex, 0, removedCard);
 
-        if (removedCard.id !== targetCardId) {
-          // Unexpected card is chosen
-          window.alert("Failed moving the card. Please try again.");
-          return state;
-        }
+        checkCardIds(removedCard.id, targetCardId);
 
         state.cardsByColumnId[startColumnId] = sourceCardList;
         state.cardsByColumnId[endColumnId] = destCardList;

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -77,7 +77,6 @@ export const slice = createSlice({
     builder.addCase(getBoardThunk.fulfilled, (state, action) => {
       const cards = action.payload?.data?.cards;
       if (cards) {
-        // state.cards = cards.map((card) => convertCardToInnerType(card));
         const cardsByColumnId: Record<number, InnerCard[]> = {};
         cards
           .map((card) => convertCardToInnerType(card))

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -50,7 +50,7 @@ export const slice = createSlice({
   },
 });
 
-export const selectCards = (state: RootState) => state.cardState.cards;
+export const selectCards = () => (state: RootState) => state.cardState.cards;
 export const { addCard } = slice.actions;
 
 export const cardReducer = slice.reducer;

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -50,6 +50,7 @@ export const slice = createSlice({
       if (!state.cardsByColumnId) return state;
 
       if (startColumnId === endColumnId) {
+        // Reorder cards in the same column.
         const targetCardList = [...state.cardsByColumnId[startColumnId]];
         const [removedCard] = targetCardList.splice(startIndex, 1);
         targetCardList.splice(endIndex, 0, removedCard);
@@ -57,6 +58,7 @@ export const slice = createSlice({
         state.cardsByColumnId[startColumnId] = targetCardList;
         return state;
       } else {
+        // Reorder cards across different columns.
         const sourceCardList = [...state.cardsByColumnId[startColumnId]];
         const [removedCard] = sourceCardList.splice(startIndex, 1);
         const destCardList = [...state.cardsByColumnId[endColumnId]];

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -1,18 +1,18 @@
-import { createSlice } from "@reduxjs/toolkit";
-import { Card as innerCard } from "src/features/card/card.g";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Card as InnerCard } from "src/features/card/card.g";
 import { Card as OuterCard } from "src/features/board/board.api";
 import { RootState } from "src/utils/redux/root";
 import { getBoardThunk } from "src/features/board/board.slice";
 
 interface CardState {
-  cards: innerCard[];
+  cards: InnerCard[];
 }
 
 const initialState: CardState = {
   cards: [],
 };
 
-const convertCardToInnerType = (ob: OuterCard): innerCard => {
+const convertCardToInnerType = (ob: OuterCard): InnerCard => {
   return {
     id: ob.id,
     title: ob.title,
@@ -31,6 +31,21 @@ export const slice = createSlice({
         columnId: action.payload.columnId,
       };
       state.cards.push(newItem);
+    },
+    reorderCards: (
+      state,
+      action: PayloadAction<{
+        cards: InnerCard[];
+        startIndex: number;
+        endIndex: number;
+      }>
+    ) => {
+      const { cards, startIndex, endIndex } = action.payload;
+      const newCardList = [...cards];
+      const [removed] = newCardList.splice(startIndex, 1);
+      newCardList.splice(endIndex, 0, removed);
+
+      state.cards = newCardList;
     },
   },
   extraReducers: (builder) => {
@@ -51,6 +66,6 @@ export const slice = createSlice({
 });
 
 export const selectCards = () => (state: RootState) => state.cardState.cards;
-export const { addCard } = slice.actions;
+export const { addCard, reorderCards } = slice.actions;
 
 export const cardReducer = slice.reducer;

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -66,37 +66,42 @@ export const slice = createSlice({
       if (startColumnId === endColumnId) {
         // Reorder cards in the same column.
         const targetCardList = [...state.cardsByColumnId[startColumnId]];
-        const [removedCard] = targetCardList.splice(startIndex, 1);
+        const [targetCard] = targetCardList.splice(startIndex, 1);
+        targetCardList.splice(endIndex, 0, targetCard);
 
-        const nextSourseCardId = targetCardList[startIndex + 1]?.id || null;
-        if (startIndex > 0) {
-          targetCardList[startIndex - 1].nextCardId = nextSourseCardId;
-        } else {
-          console.log("Should update headerCardId of column");
-          // [TODO]: Update headerCardId of column state
-        }
+        const updateLinkedListPointers = () => {
+          const nextSourseCardId = targetCardList[startIndex + 1]?.id || null;
+          const prevSourseCard = targetCardList[startIndex - 1];
 
-        const nextDestCardId = targetCardList[endIndex + 1]?.id || null;
-        removedCard.nextCardId = nextDestCardId;
+          if (startIndex > 0) {
+            // There is a previous card. Need to update next ID of previous card.
+            prevSourseCard.nextCardId = nextSourseCardId;
+          } else {
+            // There is no previous card. Need to update head's card ID of target column.
+            // [TODO]: Update headerCardId of column state
+          }
 
-        targetCardList.splice(endIndex, 0, removedCard);
+          const nextDestCardId = targetCardList[endIndex + 1]?.id || null;
+          targetCard.nextCardId = nextDestCardId;
+        };
+        updateLinkedListPointers();
 
-        checkCardIds(removedCard.id, targetCardId);
+        checkCardIds(targetCard.id, targetCardId);
 
-        // [TODO]: Update
+        // [TODO]: Hit APIs to update data in database
 
         state.cardsByColumnId[startColumnId] = targetCardList;
         return state;
       } else {
         // Reorder cards across different columns.
         const sourceCardList = [...state.cardsByColumnId[startColumnId]];
-        const [removedCard] = sourceCardList.splice(startIndex, 1);
+        const [targetCard] = sourceCardList.splice(startIndex, 1);
         const destCardList = [...state.cardsByColumnId[endColumnId]];
-        destCardList.splice(endIndex, 0, removedCard);
+        destCardList.splice(endIndex, 0, targetCard);
 
         // [TODO]: Enable to change nextCardId and headCardID then hit API to update data in database.
 
-        checkCardIds(removedCard.id, targetCardId);
+        checkCardIds(targetCard.id, targetCardId);
 
         state.cardsByColumnId[startColumnId] = sourceCardList;
         state.cardsByColumnId[endColumnId] = destCardList;

--- a/src/features/card/card.slice.ts
+++ b/src/features/card/card.slice.ts
@@ -63,7 +63,11 @@ export const slice = createSlice({
   },
 });
 
+// Selectors
 export const selectCards = () => (state: RootState) => state.cardState.cards;
-export const { addCard, reorderCards } = slice.actions;
+export const selectCardsByColumnId = (columnId: number) => (state: RootState) =>
+  state.cardState.cards.filter((card) => card.columnId === columnId);
 
+// Reducer & Actions
+export const { addCard, reorderCards } = slice.actions;
 export const cardReducer = slice.reducer;

--- a/src/features/card/card.tsx
+++ b/src/features/card/card.tsx
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import { Draggable } from "react-beautiful-dnd";
+import { Card as CardType } from "./card.g";
 
 const CardMain = styled.div`
   display: grid;
@@ -14,9 +16,22 @@ const CardMain = styled.div`
 `;
 
 interface CardProps {
-  title: string;
+  index: number;
+  card: CardType;
 }
 
-export const Card = ({ title }: CardProps) => {
-  return <CardMain>{title}</CardMain>;
+export const Card = ({ index, card }: CardProps) => {
+  return (
+    <Draggable draggableId={card.id.toString()} index={index}>
+      {(provided, snapshot) => (
+        <CardMain
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          {card.title}
+        </CardMain>
+      )}
+    </Draggable>
+  );
 };

--- a/src/features/column/column-list.tsx
+++ b/src/features/column/column-list.tsx
@@ -1,10 +1,14 @@
 import { Column } from "src/features/column/column";
 import { Column as ColumnType } from "src/features/column/column.g";
 import { useSelector } from "react-redux";
-import { selectColumns } from "src/features/column/column.slice";
+import { selectColumnsByBoardId } from "src/features/column/column.slice";
 
-export const ColumnList = () => {
-  const columns = useSelector(selectColumns());
+interface ColumnListProps {
+  boardId: number;
+}
+
+export const ColumnList = ({ boardId }: ColumnListProps) => {
+  const columns = useSelector(selectColumnsByBoardId(boardId));
 
   return (
     <>

--- a/src/features/column/column-list.tsx
+++ b/src/features/column/column-list.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { selectColumns } from "src/features/column/column.slice";
 
 export const ColumnList = () => {
-  const columns = useSelector(selectColumns);
+  const columns = useSelector(selectColumns());
 
   return (
     <>

--- a/src/features/column/column.g.ts
+++ b/src/features/column/column.g.ts
@@ -3,4 +3,5 @@ import { Card } from "src/features/card/card.g";
 export interface Column {
   id: number;
   title?: string;
+  boardId: number;
 }

--- a/src/features/column/column.g.ts
+++ b/src/features/column/column.g.ts
@@ -2,4 +2,5 @@ export interface Column {
   id: number;
   title?: string;
   boardId: number;
+  headCardId?: number;
 }

--- a/src/features/column/column.g.ts
+++ b/src/features/column/column.g.ts
@@ -1,5 +1,3 @@
-import { Card } from "src/features/card/card.g";
-
 export interface Column {
   id: number;
   title?: string;

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -16,6 +16,7 @@ const convertColumnToInnerType = (ob: OuterColumn): innerColumn => {
   return {
     id: ob.id,
     title: ob.title,
+    boardId: ob.boardId,
   };
 };
 
@@ -49,7 +50,9 @@ export const slice = createSlice({
 // Selectors
 export const selectColumns = () => (state: RootState) =>
   state.columnState.columns;
-export const { addColumn } = slice.actions;
+export const selectColumnsByBoardId = (boardId: number) => (state: RootState) =>
+  state.columnState.columns.filter((column) => column.boardId === boardId);
 
 // Reducer & Actions
+export const { addColumn } = slice.actions;
 export const columnReducer = slice.reducer;

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -46,8 +46,10 @@ export const slice = createSlice({
   },
 });
 
+// Selectors
 export const selectColumns = () => (state: RootState) =>
   state.columnState.columns;
 export const { addColumn } = slice.actions;
 
+// Reducer & Actions
 export const columnReducer = slice.reducer;

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -28,6 +28,7 @@ export const slice = createSlice({
       const newItem = {
         id: Math.floor(100000 + Math.random() * 900000),
         title: action.payload,
+        boardId: 0,
       };
       state.columns.push(newItem);
     },

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -46,7 +46,8 @@ export const slice = createSlice({
   },
 });
 
-export const selectColumns = (state: RootState) => state.columnState.columns;
+export const selectColumns = () => (state: RootState) =>
+  state.columnState.columns;
 export const { addColumn } = slice.actions;
 
 export const columnReducer = slice.reducer;

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -49,8 +49,6 @@ export const slice = createSlice({
 });
 
 // Selectors
-export const selectColumns = () => (state: RootState) =>
-  state.columnState.columns;
 export const selectColumnsByBoardId = (boardId: number) => (state: RootState) =>
   state.columnState.columns.filter((column) => column.boardId === boardId);
 

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -12,11 +12,12 @@ const initialState: ColumnState = {
   columns: [],
 };
 
-const convertColumnToInnerType = (ob: OuterColumn): innerColumn => {
+const convertColumnToInnerType = (outerColumn: OuterColumn): innerColumn => {
   return {
-    id: ob.id,
-    title: ob.title,
-    boardId: ob.boardId,
+    id: outerColumn.id,
+    title: outerColumn.title,
+    boardId: outerColumn.boardId,
+    headCardId: outerColumn.headCardId,
   };
 };
 

--- a/src/features/column/column.slice.ts
+++ b/src/features/column/column.slice.ts
@@ -35,9 +35,9 @@ export const slice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(getBoardThunk.fulfilled, (state, action) => {
-      const data = action.payload?.data;
-      if (data) {
-        state.columns = data.columns.map((column) =>
+      const columns = action.payload?.data?.columns;
+      if (columns) {
+        state.columns = columns.map((column) =>
           convertColumnToInnerType(column)
         );
       }

--- a/src/features/column/column.tsx
+++ b/src/features/column/column.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { CardList } from "src/features/card/card-list";
 import { NewCard } from "src/features/card/new-card";
 import { colors } from "src/utils/styles";
+import { Droppable } from "react-beautiful-dnd";
 
 const Container = styled.div`
   display: grid;
@@ -38,13 +39,17 @@ interface ColumnProps {
 // Column component responsible for each column within the board
 export const Column = ({ columnId, title }: ColumnProps) => {
   return (
-    <Container>
-      <Header>
-        <Title>{title}</Title>
-        <span>...</span>
-      </Header>
-      <CardList columnId={columnId} />
-      <NewCard columnId={columnId} />
-    </Container>
+    <Droppable droppableId="cards">
+      {(provided, snapshot) => (
+        <Container {...provided.droppableProps} ref={provided.innerRef}>
+          <Header>
+            <Title>{title}</Title>
+            <span>...</span>
+          </Header>
+          <CardList columnId={columnId} />
+          <NewCard columnId={columnId} />
+        </Container>
+      )}
+    </Droppable>
   );
 };

--- a/src/features/column/column.tsx
+++ b/src/features/column/column.tsx
@@ -36,10 +36,12 @@ interface ColumnProps {
   title: string;
 }
 
-// Column component responsible for each column within the board
+/**
+ * Column component responsible for each column within the board
+ */
 export const Column = ({ columnId, title }: ColumnProps) => {
   return (
-    <Droppable droppableId="cards">
+    <Droppable droppableId={columnId.toString()}>
       {(provided, snapshot) => (
         <Container {...provided.droppableProps} ref={provided.innerRef}>
           <Header>

--- a/src/features/user/user.slice.ts
+++ b/src/features/user/user.slice.ts
@@ -43,8 +43,10 @@ export const slice = createSlice({
   },
 });
 
+// Selectors
 export const selectCurrentUser = () => (state: RootState) =>
   state.userState.currentUser;
 
+// Reducer & Actions
 export const { resetCurrentUser } = slice.actions;
 export const userReducer = slice.reducer;

--- a/src/pages/boards/[id].tsx
+++ b/src/pages/boards/[id].tsx
@@ -4,8 +4,7 @@ import { useRouter } from "next/router";
 import styled from "styled-components";
 import Image from "next/image";
 import { Navbar } from "src/features/board/navbar";
-import { NewColumn } from "src/features/column/new-column";
-import { ColumnList } from "src/features/column/column-list";
+import { Board } from "src/features/board/board";
 import { Subnav } from "src/features/board/subnav";
 import { imagePath } from "src/utils/url/drello-web";
 import { getBoardThunk, selectBoardById } from "src/features/board/board.slice";
@@ -24,19 +23,7 @@ const BoardImage = styled(Image)`
   z-index: -99;
 `;
 
-const Container = styled.section`
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
-  gap: 1rem;
-  padding: 1em;
-  justify-content: start;
-  justify-items: start;
-  align-items: flex-start;
-  overflow-x: auto;
-`;
-
-const Board = () => {
+const BoardPage = () => {
   const { idToken, currentUser } = useAuth();
   const dispatch = useDispatch();
   const router = useRouter();
@@ -69,13 +56,10 @@ const Board = () => {
       <Main>
         <Navbar />
         <Subnav name="Drello" />
-        <Container>
-          <ColumnList />
-          <NewColumn />
-        </Container>
+        <Board />
       </Main>
     </>
   );
 };
 
-export default Board;
+export default BoardPage;

--- a/src/pages/boards/[id].tsx
+++ b/src/pages/boards/[id].tsx
@@ -56,7 +56,7 @@ const BoardPage = () => {
       <Main>
         <Navbar />
         <Subnav name="Drello" />
-        <Board />
+        <Board boardId={boardId} />
       </Main>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,13 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
+
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
@@ -2681,6 +2688,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3247,6 +3259,11 @@ queue@6.0.2:
   dependencies:
     inherits "~2.0.3"
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -3272,6 +3289,19 @@ raw-body@2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-beautiful-dnd@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
+  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
+
 react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -3296,7 +3326,7 @@ react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-redux@^7.2.5:
+react-redux@^7.2.0, react-redux@^7.2.5:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
   integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
@@ -3355,7 +3385,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.0.0, redux@^4.1.2:
+redux@^4.0.0, redux@^4.0.4, redux@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
   integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
@@ -3814,6 +3844,11 @@ timers-browserify@2.0.12, timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-invariant@^1.0.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
 tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -3948,6 +3983,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
+  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
 
 use-subscription@1.5.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/react-beautiful-dnd@^13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.2.tgz#510405abb09f493afdfd898bf83995dc6385c130"
+  integrity sha512-+OvPkB8CdE/bGdXKyIhc/Lm2U7UAYCCJgsqmopFmh9gbAudmslkI8eOrPDjg4JhwSE6wytz4a3/wRjKtovHVJg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.19", "@types/react-redux@^7.1.20":
   version "7.1.21"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.21.tgz#f32bbaf7cbc4b93f51e10d340aa54035c084b186"


### PR DESCRIPTION
Enabled to drag and drop to cards without connecting APIs.

- Installed [`react-beautiful-dnd`](https://github.com/atlassian/react-beautiful-dnd)
- Store Card's data divided by column to make it easy to manage the order of cards
- To enable to manage order and store them in database, added nextCarId to Card's type and headCardId to Column's type

https://user-images.githubusercontent.com/12164726/147995349-3b25ae62-fdf9-4e76-8610-15954c2b329b.mov

